### PR TITLE
Fix publication of SNAPSHOT from master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           fail_ci_if_error: true
 
       - name: Snapshot
-        if: ${{ github.ref == 'ref/head/master' }}
+        if: github.ref == 'refs/heads/master'
         run: >-
           ./gradlew
           $GRADLE_ARGS


### PR DESCRIPTION
Had a typo in the ref path (`head` → `heads`) and using shorter notation as shown in https://stackoverflow.com/a/58142412.