### PR TITLE
Install to Maven local for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,20 @@ jobs:
       - name: Check
         run: ./gradlew $GRADLE_ARGS check jacocoTestReport
 
+      - name: Keyring
+        run: echo "${{ secrets.SIGNING_SECRET_KEY_RING }}" | base64 --decode > "$HOME/secring.gpg"
+
+      - name: Publish Locally
+        run: >-
+          ./gradlew
+          $GRADLE_ARGS
+          --no-parallel
+          -PVERSION_NAME=unspecified
+          -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}"
+          -Psigning.password="${{ secrets.SIGNING_PASSWORD }}"
+          -Psigning.secretKeyRingFile="$HOME/secring.gpg"
+          installArchives
+
       - name: Codecov
         uses: codecov/codecov-action@v1
         with:


### PR DESCRIPTION
Validates that project is ready for later Maven **Central** publication by performing a signed Maven **Local** installation during CI check.