### PR TITLE
Use 'publishMavenLocal' Gradle task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           -Psigning.keyId="${{ secrets.SIGNING_KEY_ID }}"
           -Psigning.password="${{ secrets.SIGNING_PASSWORD }}"
           -Psigning.secretKeyRingFile="$HOME/secring.gpg"
-          installArchives
+          publishToMavenLocal
 
       - name: Codecov
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
TIL: `installArchives` is deprecated.

Discovered while installing [Krayon](https://github.com/JuulLabs/krayon) locally:

```
> Task :kanvas:installArchives
The task installArchives is deprecated use publishToMavenLocal instead.
```