### PR TITLE
Migrate `Parceler` package

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ kotlin = "1.6.10"
 [libraries]
 assertj = { module = "org.assertj:assertj-core", version = "3.21.0" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version = "1.10.2" }
+kotlin-parcelize-runtime = { module = "org.jetbrains.kotlin:kotlin-parcelize-runtime", version = "1.6.10" }
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version = "1.6.10-1.0.2" }
 ksp-testing = { module = "com.github.tschuchortdev:kotlin-compile-testing-ksp", version = "1.4.7" }
 robolectric = { module = "org.robolectric:robolectric", version = "4.7.3" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ kotlin = "1.6.10"
 [libraries]
 assertj = { module = "org.assertj:assertj-core", version = "3.21.0" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version = "1.10.2" }
-kotlin-parcelize-runtime = { module = "org.jetbrains.kotlin:kotlin-parcelize-runtime", version = "1.6.10" }
+kotlin-parcelize-runtime = { module = "org.jetbrains.kotlin:kotlin-parcelize-runtime", version.ref = "kotlin" }
 ksp-api = { module = "com.google.devtools.ksp:symbol-processing-api", version = "1.6.10-1.0.2" }
 ksp-testing = { module = "com.github.tschuchortdev:kotlin-compile-testing-ksp", version = "1.4.7" }
 robolectric = { module = "org.robolectric:robolectric", version = "4.7.3" }

--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -6,11 +6,11 @@ public final class com/juul/exercise/runtime/BuildConfig {
 }
 
 public final class com/juul/exercise/runtime/ParcelerExtensionsKt {
-	public static final fun createFromMarshalledBytes (Lkotlinx/android/parcel/Parceler;[BII)Ljava/lang/Object;
-	public static synthetic fun createFromMarshalledBytes$default (Lkotlinx/android/parcel/Parceler;[BIIILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun createFromMarshalledBytesOrNull (Lkotlinx/android/parcel/Parceler;[BII)Ljava/lang/Object;
-	public static synthetic fun createFromMarshalledBytesOrNull$default (Lkotlinx/android/parcel/Parceler;[BIIILjava/lang/Object;)Ljava/lang/Object;
-	public static final fun writeToMarshalledBytes (Lkotlinx/android/parcel/Parceler;Ljava/lang/Object;)[B
-	public static final fun writeToMarshalledBytesOrNull (Lkotlinx/android/parcel/Parceler;Ljava/lang/Object;)[B
+	public static final fun createFromMarshalledBytes (Lkotlinx/parcelize/Parceler;[BII)Ljava/lang/Object;
+	public static synthetic fun createFromMarshalledBytes$default (Lkotlinx/parcelize/Parceler;[BIIILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun createFromMarshalledBytesOrNull (Lkotlinx/parcelize/Parceler;[BII)Ljava/lang/Object;
+	public static synthetic fun createFromMarshalledBytesOrNull$default (Lkotlinx/parcelize/Parceler;[BIIILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun writeToMarshalledBytes (Lkotlinx/parcelize/Parceler;Ljava/lang/Object;)[B
+	public static final fun writeToMarshalledBytesOrNull (Lkotlinx/parcelize/Parceler;Ljava/lang/Object;)[B
 }
 

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -18,6 +18,7 @@ android {
 }
 
 dependencies {
+    api(libs.kotlin.parcelize.runtime)
     testImplementation(libs.assertj)
     testImplementation(kotlin("test-junit"))
     testImplementation(libs.robolectric)

--- a/runtime/src/main/kotlin/com/juul/exercise/runtime/ParcelerExtensions.kt
+++ b/runtime/src/main/kotlin/com/juul/exercise/runtime/ParcelerExtensions.kt
@@ -1,7 +1,7 @@
 package com.juul.exercise.runtime
 
 import android.os.Parcel
-import kotlinx.android.parcel.Parceler
+import kotlinx.parcelize.Parceler
 
 fun <T : Any> Parceler<T>.createFromMarshalledBytes(
     data: ByteArray,

--- a/runtime/src/test/java/com/juul/exercise/runtime/ParcelerExtensionTests.kt
+++ b/runtime/src/test/java/com/juul/exercise/runtime/ParcelerExtensionTests.kt
@@ -1,7 +1,7 @@
 package com.juul.exercise.runtime
 
 import android.os.Parcel
-import kotlinx.android.parcel.Parceler
+import kotlinx.parcelize.Parceler
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith


### PR DESCRIPTION
Switches to the newer package providing this same interface. This is a breaking change.

![Screen Shot 2021-12-20 at 4 46 13 PM](https://user-images.githubusercontent.com/20380774/146852250-c9c4d50f-076b-4765-b1c3-3f57f690ca82.png)

Also, marks the dependency as an `api` in gradle