### PR TITLE
Automatically close/release on publication to Sonatype

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,11 @@ jobs:
           -PmavenCentralUsername="${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}"
           -PmavenCentralPassword="${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}"
           publish
+      - run: >-
+          ./gradlew
+          -PmavenCentralUsername="${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}"
+          -PmavenCentralPassword="${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}"
+          closeAndReleaseRepository
 
       - run: |
           rm -f ~/.gradle/caches/modules-2/modules-2.lock


### PR DESCRIPTION
As noted in the [plugin documentation](https://github.com/vanniktech/gradle-maven-publish-plugin#releasing):

> It assumes there's only one staging repository active when `closeAndReleaseRepository` is called. If you have stale staging repositories, you'll have to delete them by logging at https://oss.sonatype.org/ (or you Nexus instance).