### PR TITLE
Setup Dokka

### DIFF
--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -1,0 +1,16 @@
+name: Dokka
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - run: ./gradlew dokkaHtmlMultiModule
+      - uses: JamesIves/github-pages-deploy-action@v4.3.0
+        with:
+          branch: gh-pages
+          folder: build/dokka/htmlMultiModule

--- a/annotations/build.gradle.kts
+++ b/annotations/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     kotlin("jvm")
     id("org.jmailen.kotlinter")
     jacoco
+    id("org.jetbrains.dokka")
     id("com.vanniktech.maven.publish")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,12 +10,12 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlinter) apply false
     alias(libs.plugins.validator)
-    alias(libs.plugins.dokka) apply false
+    alias(libs.plugins.dokka)
     alias(libs.plugins.maven.publish) apply false
     alias(libs.plugins.one.eight)
 }
 
-subprojects {
+allprojects {
     repositories {
         mavenCentral()
         google()

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("kotlin-parcelize")
     id("org.jmailen.kotlinter")
     jacoco
+    id("org.jetbrains.dokka")
     id("com.vanniktech.maven.publish")
 }
 


### PR DESCRIPTION
`org.jetbrains.dokka` plugin was already partially setup in the project, this PR is just doing some finishing steps to get it running (integrated into CI).

Publishes Dokka API docs for `annotations` and `runtime` modules (the `stubs` and `compile` modules didn't seem relevant for library consumers).