### PR TITLE
Use Temurin 11 JDK for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - uses: actions/setup-java@v3
         with:
-          distribution: "adopt-hotspot"
-          java-version: "11.0.11+9"
+          distribution: 'temurin'
+          java-version: '11'
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: gradle/wrapper-validation-action@v1
       - uses: actions/setup-java@v3
         with:
-          distribution: "adopt-hotspot"
-          java-version: "11.0.11+9"
+          distribution: 'temurin'
+          java-version: '11'
 
       - uses: actions/cache@v3
         with:


### PR DESCRIPTION
> NOTE: Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt to temurin to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).

— https://github.com/actions/setup-java#supported-distributions