### PR TITLE
Add documentation for Kotlin multiplatform Gradle setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,17 +11,46 @@ Exercise makes it possible to pass intent extras easily and correctly.
 
 First, add it to gradle.
 
-```gradle
+<details open>
+<summary>Kotlin multiplatform</summary>
+
+```kotlin
+repositories {
+  mavenCentral()
+}
+
+kotlin {
+  android()
+
+  val androidMain by getting {
+    dependencies {
+      implementation("com.juul.exercise:annotations:$version")
+      implementation("com.juul.exercise:runtime:$version")
+    }
+  }
+}
+
+dependencies {
+  add("kspAndroid", "com.juul.exercise:compile:$version")
+}
+```
+</details>
+
+<details>
+<summary>Android project</summary>
+
+```kotlin
 repositories {
   mavenCentral()
 }
 
 dependencies {
-  implementation "com.juul.exercise:annotations:$version"
-  implementation "com.juul.exercise:runtime:$version"
-  ksp "com.juul.exercise:compile:$version"
+  implementation("com.juul.exercise:annotations:$version")
+  implementation("com.juul.exercise:runtime:$version")
+  ksp("com.juul.exercise:compile:$version")
 }
 ```
+</details>
 
 Then, create your activity.
 


### PR DESCRIPTION
Rendered markdown [here](https://github.com/JuulLabs/exercise/tree/twyatt/doc/gradle-kmp#getting-started).

Documentation for setting up KSP for Kotlin multiplatform projects can be found [here](https://kotlinlang.org/docs/ksp-multiplatform.html).