### PR TITLE
Clean up / simplify CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,15 @@
 name: CI
 on:
   pull_request:
+  # Trigger on merges to `main` to allow `gradle/gradle-build-action` runs to write their caches.
+  # https://github.com/gradle/gradle-build-action#using-the-caches-read-only
+  push:
+    branches:
+      - main
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
@@ -13,42 +18,24 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
-      - uses: actions/cache@v3
+      - name: check jacocoTestReport
+        uses: gradle/gradle-build-action@v2
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ~/.konan
-            ~/.android/build-cache
-            ~/.android/cache
-          key: ${{ runner.os }}-build-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          arguments: check jacocoTestReport
 
-      - run: ./gradlew check jacocoTestReport
       - uses: EnricoMi/publish-unit-test-result-action@v2
         with:
           junit_files: '**/build/test-results/**/*.xml'
           report_individual_runs: 'true'
 
-      - run: |
-          set -o xtrace
-          if [ ! -z "${{ secrets.SIGNING_KEY }}" ]; then
-            ./gradlew \
-            -PVERSION_NAME="unspecified" \
-            -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}" \
-            -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}" \
+      - name: publishToMavenLocal
+        if: github.repository_owner == 'JuulLabs'
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: |
+            -PVERSION_NAME="unspecified"
+            -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}"
+            -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}"
             publishToMavenLocal
-          else
-            ./gradlew \
-            -PVERSION_NAME="unspecified" \
-            -PRELEASE_SIGNING_ENABLED=false \
-            publishToMavenLocal
-          fi
 
       - uses: codecov/codecov-action@v3
-
-      - run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: |
-            -PVERSION_NAME="unspecified"
-            -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}"
-            -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}"
+            -PVERSION_NAME=unspecified
+            -PsigningInMemoryKey=${{ secrets.SIGNING_KEY }}
+            -PsigningInMemoryKeyPassword=${{ secrets.SIGNING_PASSWORD }}
             publishToMavenLocal
 
       - uses: codecov/codecov-action@v3

--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -6,10 +6,15 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - run: ./gradlew dokkaHtmlMultiModule
+
+      - name: dokkaHtmlMultiModule
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: dokkaHtmlMultiModule
+
       - uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           folder: build/dokka/htmlMultiModule

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: |
-            -PVERSION_NAME="${GITHUB_REF/refs\/tags\//}"
+            -PVERSION_NAME=${GITHUB_REF/refs\/tags\//}
             -PsigningInMemoryKey=${{ secrets.SIGNING_KEY }}
             -PsigningInMemoryKeyPassword=${{ secrets.SIGNING_PASSWORD }}
             -PmavenCentralUsername=${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
@@ -15,29 +15,18 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
 
-      - uses: actions/cache@v3
+      - name: check
+        uses: gradle/gradle-build-action@v2
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-            ~/.konan
-            ~/.android/build-cache
-            ~/.android/cache
-          key: ${{ runner.os }}-publish-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-publish-
-            ${{ runner.os }}-
+          arguments: check
 
-      - run: ./gradlew check
-      - run: >-
-          ./gradlew
-          -PVERSION_NAME="${GITHUB_REF/refs\/tags\//}"
-          -PsigningInMemoryKey="${{ secrets.SIGNING_KEY }}"
-          -PsigningInMemoryKeyPassword="${{ secrets.SIGNING_PASSWORD }}"
-          -PmavenCentralUsername="${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}"
-          -PmavenCentralPassword="${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}"
-          publish
-
-      - run: |
-          rm -f ~/.gradle/caches/modules-2/modules-2.lock
-          rm -f ~/.gradle/caches/modules-2/gc.properties
+      - name: publish
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: |
+            -PVERSION_NAME="${GITHUB_REF/refs\/tags\//}"
+            -PsigningInMemoryKey=${{ secrets.SIGNING_KEY }}
+            -PsigningInMemoryKeyPassword=${{ secrets.SIGNING_PASSWORD }}
+            -PmavenCentralUsername=${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
+            -PmavenCentralPassword=${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
+            publish


### PR DESCRIPTION
- Updates GitHub virtual environments to Ubuntu 22.04 (from 20.04)
- Uses `gradle/gradle-build-action@v2` for Gradle execution (to get its caching support, and remove the manual caching setup)
- Skips local maven publish on forks