### PR TITLE
Use JDK 17 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: check jacocoTestReport
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: check
         uses: gradle/gradle-build-action@v2

--- a/annotations/build.gradle.kts
+++ b/annotations/build.gradle.kts
@@ -7,3 +7,7 @@ plugins {
 }
 
 apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
+
+kotlin {
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,6 @@ plugins {
     alias(libs.plugins.validator)
     alias(libs.plugins.dokka)
     alias(libs.plugins.maven.publish) apply false
-    alias(libs.plugins.one.eight)
 }
 
 allprojects {

--- a/compile/build.gradle.kts
+++ b/compile/build.gradle.kts
@@ -9,6 +9,7 @@ apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
 
 kotlin {
     explicitApi()
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
 }
 
 dependencies {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 agp = "7.4.2"
 android-compile = "android-30"
 android-min = "21"
+jvm-toolchain = "11"
 kotlin = "1.8.21"
 
 [libraries]
@@ -20,5 +21,4 @@ dokka = { id = "org.jetbrains.dokka", version = "1.8.10" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "3.14.0" }
 maven-publish = { id = "com.vanniktech.maven.publish", version = "0.25.2" }
-one-eight = { id = "net.mbonnin.one.eight", version = "0.2" }
 validator = { id = "binary-compatibility-validator", version = "0.13.0" }

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -10,7 +10,18 @@ plugins {
 
 apply(from = rootProject.file("gradle/jacoco.gradle.kts"))
 
+kotlin {
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
+}
+
 android {
+    // Workaround (for `jvmToolchain` not being honored) needed until AGP 8.1.0-alpha09.
+    // https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     compileSdkVersion(libs.versions.android.compile.get())
 
     defaultConfig {

--- a/stubs/build.gradle.kts
+++ b/stubs/build.gradle.kts
@@ -2,3 +2,7 @@ plugins {
     kotlin("jvm")
     id("com.vanniktech.maven.publish")
 }
+
+kotlin {
+    jvmToolchain(libs.versions.jvm.toolchain.get().toInt())
+}


### PR DESCRIPTION
Newer versions of AGP require JDK 17:

```
An exception occurred applying plugin request [id: 'com.android.library', artifact: 'com.android.tools.build:gradle:null']
> Failed to apply plugin 'com.android.internal.library'.
   > Android Gradle plugin requires Java 17 to run. You are currently using Java 11.
      Your current JDK is located in /Users/runner/hostedtoolcache/Java_Temurin-Hotspot_jdk/11.0.18-10/x64/Contents/Home
      You can try some of the following options:
       - changing the IDE settings.
       - changing the JAVA_HOME environment variable.
       - changing `org.gradle.java.home` in `gradle.properties`.
```