### PR TITLE
Use `github.ref_name` for version during publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: |
-            -PVERSION_NAME=${GITHUB_REF/refs\/tags\//}
+            -PVERSION_NAME=${{ github.ref_name }}
             -PsigningInMemoryKey=${{ secrets.SIGNING_KEY }}
             -PsigningInMemoryKeyPassword=${{ secrets.SIGNING_PASSWORD }}
             -PmavenCentralUsername=${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}


### PR DESCRIPTION
For some reason `${GITHUB_REF/refs\/tags\//}` [doesn't evaluate properly](https://github.com/JuulLabs/exercise/actions/runs/4983428935) when using `gradle/gradle-build-action@v2`. Using `${{ github.ref_name }}` instead.