### PR TITLE
Use major-only version for `github-pages-deploy-action`

### DIFF
--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           arguments: dokkaHtmlMultiModule
 
-      - uses: JamesIves/github-pages-deploy-action@v4.4.1
+      - uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: build/dokka/htmlMultiModule


### PR DESCRIPTION
Noticed that this action has major-only version tags available, which reduces version bump churn.