### PR TITLE
Use JDK 17 for Dokka publication on CI

### DIFF
--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
 
       - name: dokkaHtmlMultiModule
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
Dokka publication is [failing](https://github.com/JuulLabs/exercise/actions/runs/5293030992), this should fix it. 🤞 

```
* What went wrong:
An exception occurred applying plugin request [id: 'com.android.library', artifact: 'com.android.tools.build:gradle:null']
> Failed to apply plugin 'com.android.internal.library'.
   > Android Gradle plugin requires Java 17 to run. You are currently using Java 11.
      Your current JDK is located in /usr/lib/jvm/temurin-11-jdk-amd64
      You can try some of the following options:
       - changing the IDE settings.
       - changing the JAVA_HOME environment variable.
       - changing `org.gradle.java.home` in `gradle.properties`.
```