### PR TITLE
Remove reference to Compose in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   ],
   "packageRules": [
     {
-      "groupName": "Kotlin, KSP and Compose",
+      "groupName": "Kotlin and KSP",
       "matchPackagePrefixes": [
         "org.jetbrains.kotlin:",
         "org.jetbrains.kotlin.",


### PR DESCRIPTION
This project doesn't use Compose, so including it in Renovate PR titles can create confusion.