### PR TITLE
Simplify `binary-compatibility-validator` setup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlinter) apply false
-    alias(libs.plugins.validator)
+    alias(libs.plugins.api)
     alias(libs.plugins.dokka)
     alias(libs.plugins.maven.publish) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,8 +17,8 @@ tuulbox-logging = { module = "com.juul.tuulbox:logging", version = "7.2.0" }
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+api = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.14.0" }
 dokka = { id = "org.jetbrains.dokka", version = "1.9.20" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "4.2.0" }
 maven-publish = { id = "com.vanniktech.maven.publish", version = "0.27.0" }
-validator = { id = "binary-compatibility-validator", version = "0.14.0" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,20 +4,6 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
     }
-
-    resolutionStrategy {
-        eachPlugin {
-            when (requested.id.id) {
-                "binary-compatibility-validator" ->
-                    useModule("org.jetbrains.kotlinx:binary-compatibility-validator:${requested.version}")
-
-                else -> when (requested.id.namespace) {
-                    "com.android" ->
-                        useModule("com.android.tools.build:gradle:${requested.version}")
-                }
-            }
-        }
-    }
 }
 
 include(


### PR DESCRIPTION
Updates configuration to more closely match [official setup instructions](https://github.com/Kotlin/binary-compatibility-validator?tab=readme-ov-file#setup) (by not configuring/using a shorthand name for the plugin — in other words: no longer using `resolutionStrategy`).