### PR TITLE
Migrate to `gradle/actions/setup-gradle`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,15 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
-
-      - name: check jacocoTestReport
-        uses: gradle/gradle-build-action@v3
+      - uses: gradle/actions/setup-gradle@v3
         with:
-          arguments: check jacocoTestReport
+          validate-wrappers: true
+
+      - run: ./gradlew check jacocoTestReport
 
       - uses: EnricoMi/publish-unit-test-result-action@v2
         with:
@@ -30,12 +29,11 @@ jobs:
 
       - name: publishToMavenLocal
         if: github.repository_owner == 'JuulLabs'
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: |
-            -PVERSION_NAME=unspecified
-            -PsigningInMemoryKey=${{ secrets.SIGNING_KEY }}
-            -PsigningInMemoryKeyPassword=${{ secrets.SIGNING_PASSWORD }}
-            publishToMavenLocal
+        run: >
+          ./gradlew
+          -PVERSION_NAME=unspecified
+          -PsigningInMemoryKey='${{ secrets.SIGNING_KEY }}'
+          -PsigningInMemoryKeyPassword='${{ secrets.SIGNING_PASSWORD }}'
+          publishToMavenLocal
 
       - uses: codecov/codecov-action@v4

--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -13,11 +13,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '17'
+      - uses: gradle/actions/setup-gradle@v3
 
-      - name: dokkaHtmlMultiModule
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: dokkaHtmlMultiModule
+      - run: ./gradlew dokkaHtmlMultiModule
 
       - uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,24 +9,20 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
+      - uses: gradle/actions/setup-gradle@v3
 
-      - name: check
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: check
+      - run: ./gradlew check
 
       - name: publish
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: |
-            -PVERSION_NAME=${{ github.ref_name }}
-            -PsigningInMemoryKey=${{ secrets.SIGNING_KEY }}
-            -PsigningInMemoryKeyPassword=${{ secrets.SIGNING_PASSWORD }}
-            -PmavenCentralUsername=${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
-            -PmavenCentralPassword=${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
-            publish
+        run: >
+          ./gradlew
+          -PVERSION_NAME='${{ github.ref_name }}'
+          -PsigningInMemoryKey='${{ secrets.SIGNING_KEY }}'
+          -PsigningInMemoryKeyPassword='${{ secrets.SIGNING_PASSWORD }}'
+          -PmavenCentralUsername='${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}'
+          -PmavenCentralPassword='${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}'
+          publish


### PR DESCRIPTION
The currently used [`gradle/gradle-build-action`](https://github.com/gradle/gradle-build-action/blob/main/README.md) is deprecated in favor of [`gradle/actions/setup-gradle`](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md).