### PR TITLE
Add `.kotlin/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
 *.iml
-.gradle
-/local.properties
-/.idea
 .DS_Store
-build/
-/captures
-.externalNativeBuild
 .cxx
+.externalNativeBuild
+.gradle
+.kotlin/
+/.idea
+/captures
+/local.properties
+build/


### PR DESCRIPTION
Wups, I should've added this change in #295.

https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects