### PR TITLE
Use `CENTRAL_PORTAL` Sonatype host for publication

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 
-SONATYPE_HOST=DEFAULT
+SONATYPE_HOST=CENTRAL_PORTAL
 SONATYPE_AUTOMATIC_RELEASE=true
 RELEASE_SIGNING_ENABLED=true
 


### PR DESCRIPTION
Updates Sonatype host per [`gradle-maven-publish-plugin` release notes](https://github.com/vanniktech/gradle-maven-publish-plugin/releases/tag/0.33.0).